### PR TITLE
Add missing comma in string list

### DIFF
--- a/guppy/heapy/RefPat.py
+++ b/guppy/heapy/RefPat.py
@@ -538,7 +538,7 @@ class _GLUECLAMP_:
 
     _uniset_exports = ('rp',)
     _chgable_ = ('er',
-                 'depth'
+                 'depth',
                  'line_length',
                  )
 


### PR DESCRIPTION
In python, a missing comma within a string list leads to an implicit string concatenation, which is often unintended.