### PR TITLE
Skip modules that don't have __dict__ attributes

### DIFF
--- a/guppy/heapy/View.py
+++ b/guppy/heapy/View.py
@@ -539,7 +539,7 @@ def prime_builtin_types():
     import weakref
 
     for mod in list(sys.modules.values()):
-        if mod is None:
+        if mod is None or getattr(mod, '__dict__', None) is None:
             continue
         for t in list(mod.__dict__.values()):
             if isinstance(t, type):


### PR DESCRIPTION
Fixes a problem with hpy() when coverage module is loaded, because it doesn't have a __dict__ attribute.

Closes #16 