### PR TITLE
Update View.py to ignore ImportError

### DIFF
--- a/guppy/heapy/View.py
+++ b/guppy/heapy/View.py
@@ -156,6 +156,8 @@ class _GLUECLAMP_:
                 hd = getattr(m, '_NyHeapDefs_')
             except AttributeError:
                 continue
+            except ImportError:
+                continue
             if not hd or not isinstance(hd, self.capsule_type):
                 continue
             heapdefs.append(hd)


### PR DESCRIPTION
Getting an ImportError when using guppy3 on a Textual app.

ImportError: Package 'textual.widgets' has no class '_NyHeapDefs_'